### PR TITLE
Center header layout and navigation alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
         }
         
         /* Reset and Base Styles */
-        * {
+        *, *::before, *::after {
             margin: 0;
             padding: 0;
             box-sizing: border-box;
@@ -50,10 +50,12 @@
             list-style: none;
         }
         
-        .container {
-            width: 90%;
+        .container,
+        .container-xl {
             max-width: 1200px;
             margin: 0 auto;
+            padding: 0 24px;
+            width: 100%;
         }
         
         .btn {
@@ -149,7 +151,7 @@
             display: flex;
             align-items: center;
             justify-content: space-between;
-            padding: 10px 40px;
+            padding: 10px 0;
             font-size: 0.9rem;
         }
 
@@ -162,27 +164,36 @@
         }
         
         .main-header {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            padding: 0;
-            margin: 0;
-            width: 100%;
-            box-sizing: border-box;
+            padding: 16px 0;
         }
 
         .header-content {
-            display: flex;
-            justify-content: space-between;
+            display: grid;
+            grid-template-columns: 1fr auto 1fr;
             align-items: center;
+            column-gap: 24px;
             width: 100%;
-            padding: 10px 40px;
-            box-sizing: border-box;
         }
-        
+
         .logo {
             display: flex;
             align-items: center;
+            grid-column: 1 / 2;
+            justify-self: start;
+        }
+
+        .header-center {
+            grid-column: 2 / 3;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 24px;
+        }
+
+        .header-spacer {
+            grid-column: 3 / 4;
+            height: 0;
+            visibility: hidden;
         }
 
         .site-logo {
@@ -196,9 +207,8 @@
         }
         
         .search-bar {
-            flex: 1;
-            max-width: 500px;
-            margin: 0 20px;
+            flex: 0 1 520px;
+            width: min(520px, 100%);
             position: relative;
         }
         
@@ -232,10 +242,11 @@
         .header-actions {
             display: flex;
             align-items: center;
+            gap: 20px;
         }
-        
+
         .header-actions a {
-            margin-left: 20px;
+            margin-left: 0;
             font-size: 1.2rem;
             color: var(--black);
             position: relative;
@@ -267,20 +278,19 @@
             background-color: var(--black);
         }
 
-        nav .container {
+        .nav-inner {
             display: flex;
             align-items: center;
-            justify-content: space-between;
-            padding: 10px 40px;
+            justify-content: center;
+            padding: 10px 0;
             width: 100%;
-            margin: 0;
-            box-sizing: border-box;
         }
 
         .nav-links {
             display: flex;
-            justify-content: flex-start;
-            width: 100%;
+            justify-content: center;
+            flex-wrap: wrap;
+            width: auto;
         }
         
         .nav-links li {
@@ -1099,17 +1109,31 @@
         /* Responsive Styles */
         @media (max-width: 992px) {
             .header-content {
-                flex-wrap: wrap;
+                grid-template-columns: 1fr;
+                row-gap: 16px;
+                text-align: center;
+                justify-items: center;
             }
-            
+
             .logo {
-                margin-bottom: 15px;
+                justify-self: center;
             }
-            
+
             .search-bar {
-                order: 3;
-                max-width: 100%;
-                margin: 15px 0 0;
+                width: 100%;
+            }
+
+            .header-center {
+                flex-direction: column;
+                width: 100%;
+            }
+
+            .header-actions {
+                justify-content: center;
+            }
+
+            .header-spacer {
+                display: none;
             }
             
             .about-content {
@@ -1134,6 +1158,7 @@
         @media (max-width: 768px) {
             .nav-links {
                 flex-direction: column;
+                width: 100%;
             }
             
             .hero h2 {
@@ -1193,29 +1218,32 @@
 
     <!-- Header -->
     <header>
-        <div class="container main-header">
+        <div class="container-xl main-header">
             <div class="header-content">
                 <div class="logo">
                     <img src="images/TinyTailsLogo.jpg" alt="Tiny Tails Logo" class="site-logo">
                 </div>
-                <div class="search-bar">
-                    <input type="text" placeholder="Search for products...">
-                    <button><i class="fas fa-search"></i></button>
+                <div class="header-center">
+                    <div class="search-bar">
+                        <input type="text" placeholder="Search for products...">
+                        <button><i class="fas fa-search"></i></button>
+                    </div>
+                    <div class="header-actions">
+                        <a href="#"><i class="fas fa-user"></i></a>
+                        <a href="#"><i class="fas fa-heart"></i></a>
+                        <a href="#">
+                            <i class="fas fa-shopping-cart"></i>
+                            <span class="cart-count">3</span>
+                        </a>
+                    </div>
                 </div>
-                <div class="header-actions">
-                    <a href="#"><i class="fas fa-user"></i></a>
-                    <a href="#"><i class="fas fa-heart"></i></a>
-                    <a href="#">
-                        <i class="fas fa-shopping-cart"></i>
-                        <span class="cart-count">3</span>
-                    </a>
-                </div>
+                <div class="header-spacer" aria-hidden="true"></div>
             </div>
         </div>
 
         <!-- Navigation -->
         <nav>
-            <div class="container">
+            <div class="container-xl nav-inner">
                 <ul class="nav-links">
                     <li><a href="#" class="nav-link active" data-page="home">Home</a></li>
                     <li>


### PR DESCRIPTION
## Summary
- add a shared container size with consistent padding for header and navigation rows
- refactor the header into a CSS grid so the logo stays left while the search and icons stay centered
- center the main navigation links and tune responsive behavior to match the new layout

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68fc8c180be4832e9783358f73673da7