### PR TITLE
Update hero CTAs to anchor to on-page sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,17 +73,19 @@
             transition: var(--transition);
             text-align: center;
         }
-        
+
         .btn:hover {
             background-color: var(--gray);
             transform: translateY(-2px);
         }
-        
-        .btn-pink {
+
+        .btn-pink,
+        .pink-btn {
             background-color: var(--dark-pink);
         }
-        
-        .btn-pink:hover {
+
+        .btn-pink:hover,
+        .pink-btn:hover {
             background-color: #ff8cb9;
         }
         
@@ -134,8 +136,12 @@
             min-height: 80vh;
             padding: 40px 0;
         }
-        
+
         .page.active {
+            display: block;
+        }
+
+        .page:target {
             display: block;
         }
         
@@ -1266,8 +1272,8 @@
             <div class="container hero-content">
                 <h2>Premium Products &amp; Loving Care for Your Furry Friends</h2>
                 <p>Discover our wide range of high-quality pet supplies and home-from-home care services for all your pet's needs.</p>
-                <a href="https://ecoprintinnovations.github.io/Tiny-Tails/#shop" class="btn" data-page="shop">Shop Now</a>
-                <a href="https://ecoprintinnovations.github.io/Tiny-Tails/#services" class="btn btn-pink" data-page="services" style="margin-left: 15px;">Our Services</a>
+                <a href="#shop" class="btn black-btn">Shop Now</a>
+                <a href="#services" class="btn pink-btn" style="margin-left: 15px;">Our Services</a>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- point the hero buttons at the on-page #shop and #services anchors so they scroll without reloading
- ensure the shop and services sections display when targeted and reuse the pink button styling for the new class name

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68fca2034008832e8fc499a2fc57b96b