### PR TITLE
Anchor fix: adjust Shop Now scroll offset

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,10 @@
             scroll-behavior: smooth;
         }
 
+        #shop {
+            scroll-margin-top: 140px;
+        }
+
         body {
             fontfamily: 'Poppins', sans-serif;
             background-color: var(--white);


### PR DESCRIPTION
## Summary
- add a scroll margin offset to the shop section so the sticky header no longer covers the heading when using the CTA anchor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fca7c564fc832ead6159d65f27261c