### PR TITLE
Fix shop-all-products anchor placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -1276,7 +1276,7 @@
             <div class="container hero-content">
                 <h2>Premium Products &amp; Loving Care for Your Furry Friends</h2>
                 <p>Discover our wide range of high-quality pet supplies and home-from-home care services for all your pet's needs.</p>
-                <a href="#shop" class="btn black-btn">Shop Now</a>
+                <a href="#shop-all-products" class="btn black-btn">Shop Now</a>
                 <a href="#services" class="btn pink-btn" style="margin-left: 15px;">Our Services</a>
             </div>
         </section>
@@ -1295,7 +1295,7 @@
                         </div>
                         <div class="category-info">
                             <h3>Dog Supplies</h3>
-                            <a href="#" class="btn btn-outline" data-page="dog-supplies">Shop Now</a>
+                            <a href="#shop-all-products" class="btn btn-outline" data-page="dog-supplies">Shop Now</a>
                         </div>
                     </div>
                     <div class="category-card">
@@ -1304,7 +1304,7 @@
                         </div>
                         <div class="category-info">
                             <h3>Cat Supplies</h3>
-                            <a href="#" class="btn btn-outline" data-page="cat-supplies">Shop Now</a>
+                            <a href="#shop-all-products" class="btn btn-outline" data-page="cat-supplies">Shop Now</a>
                         </div>
                     </div>
                     <div class="category-card">
@@ -1313,7 +1313,7 @@
                         </div>
                         <div class="category-info">
                             <h3>Small Pets</h3>
-                            <a href="#" class="btn btn-outline" data-page="small-pets">Shop Now</a>
+                            <a href="#shop-all-products" class="btn btn-outline" data-page="small-pets">Shop Now</a>
                         </div>
                     </div>
                     <div class="category-card">
@@ -1322,7 +1322,7 @@
                         </div>
                         <div class="category-info">
                             <h3>Birds &amp; Reptiles</h3>
-                            <a href="#" class="btn btn-outline" data-page="birds-reptiles">Shop Now</a>
+                            <a href="#shop-all-products" class="btn btn-outline" data-page="birds-reptiles">Shop Now</a>
                         </div>
                     </div>
                 </div>
@@ -1491,7 +1491,7 @@
     <section id="shop" class="page">
         <div class="container">
             <div class="section-title">
-                <h2>Shop All Products</h2>
+                <h2 id="shop-all-products">Shop All Products</h2>
                 <p>Browse our complete range of pet supplies</p>
             </div>
             
@@ -1502,7 +1502,7 @@
                     </div>
                     <div class="category-info">
                         <h3>Dog Supplies</h3>
-                        <a href="#" class="btn btn-outline" data-page="dog-supplies">Shop Now</a>
+                        <a href="#shop-all-products" class="btn btn-outline" data-page="dog-supplies">Shop Now</a>
                     </div>
                 </div>
                 <div class="category-card">
@@ -1511,7 +1511,7 @@
                     </div>
                     <div class="category-info">
                         <h3>Cat Supplies</h3>
-                        <a href="#" class="btn btn-outline" data-page="cat-supplies">Shop Now</a>
+                        <a href="#shop-all-products" class="btn btn-outline" data-page="cat-supplies">Shop Now</a>
                     </div>
                 </div>
                 <div class="category-card">
@@ -1520,7 +1520,7 @@
                     </div>
                     <div class="category-info">
                         <h3>Small Pets</h3>
-                        <a href="#" class="btn btn-outline" data-page="small-pets">Shop Now</a>
+                        <a href="#shop-all-products" class="btn btn-outline" data-page="small-pets">Shop Now</a>
                     </div>
                 </div>
                 <div class="category-card">
@@ -1529,7 +1529,7 @@
                     </div>
                     <div class="category-info">
                         <h3>Birds &amp; Reptiles</h3>
-                        <a href="#" class="btn btn-outline" data-page="birds-reptiles">Shop Now</a>
+                        <a href="#shop-all-products" class="btn btn-outline" data-page="birds-reptiles">Shop Now</a>
                     </div>
                 </div>
             </div>
@@ -1790,7 +1790,7 @@
             <div class="sale-banner">
                 <h2>Summer Sale</h2>
                 <p>Up to 50% off selected items</p>
-                <a href="#" class="btn">Shop Now</a>
+                <a href="#shop-all-products" class="btn">Shop Now</a>
             </div>
             
             <div class="section-title">


### PR DESCRIPTION
## Summary
- move the `shop-all-products` anchor id onto the Shop All Products heading for a precise scroll target

## Testing
- npx --yes prettier --check index.html *(fails: repository HTML does not match Prettier formatting)*

------
https://chatgpt.com/codex/tasks/task_e_68fd09f1ca80832e8b21ef0432fa8cd5