### PR TITLE
Fix Shop Now anchors for smooth scrolling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2,6 +2,10 @@
   color-scheme: light;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   background-color: #ffffff;
   color: #333333;
@@ -117,6 +121,10 @@ textarea:focus-visible {
   background-color: #333333;
   color: #ffffff;
   border: 2px solid transparent;
+}
+
+#shop-all-products {
+  scroll-margin-top: 120px;
 }
 
 .btn-secondary:hover,

--- a/index.html
+++ b/index.html
@@ -1489,9 +1489,9 @@
     </section>
     <!-- Shop Page -->
     <section id="shop" class="page">
-        <div class="container">
+        <div id="shop-all-products" class="container">
             <div class="section-title">
-                <h2 id="shop-all-products">Shop All Products</h2>
+                <h2>Shop All Products</h2>
                 <p>Browse our complete range of pet supplies</p>
             </div>
             


### PR DESCRIPTION
## Summary
- move the `shop-all-products` anchor to the Shop section container so it marks the top of the product block
- ensure smooth scrolling with a scroll-margin offset for the sticky header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd0deb1bc4832eb4da86f7cef4885b