### PR TITLE
Fix dog supplies navigation link paths

### DIFF
--- a/dog-supplies.html
+++ b/dog-supplies.html
@@ -994,8 +994,8 @@
         <nav>
             <div class="container-xl nav-inner">
                 <ul class="nav-links">
-                    <li><a href="/index.html" class="nav-link" data-page="home">Home</a></li>
-                    <li><a href="/dog-supplies.html" class="nav-link active">Dog Supplies</a></li>
+                    <li><a href="index.html" class="nav-link" data-page="home">Home</a></li>
+                    <li><a href="dog-supplies.html" class="nav-link active">Dog Supplies</a></li>
                     <li>
                         <a href="#" class="nav-link" data-page="shop">Shop <i class="fas fa-chevron-down"></i></a>
                         <div class="dropdown">
@@ -1020,7 +1020,7 @@
         <div class="breadcrumb">
             <div class="container">
                 <ol>
-                    <li><a href="/index.html">Home</a></li>
+                    <li><a href="index.html">Home</a></li>
                     <li>Dog Supplies</li>
                 </ol>
             </div>

--- a/index.html
+++ b/index.html
@@ -1248,8 +1248,8 @@
         <nav>
             <div class="container-xl nav-inner">
                 <ul class="nav-links">
-                    <li><a href="/index.html" class="nav-link active" data-page="home">Home</a></li>
-                    <li><a href="/dog-supplies.html" class="nav-link">Dog Supplies</a></li>
+                    <li><a href="index.html" class="nav-link active" data-page="home">Home</a></li>
+                    <li><a href="dog-supplies.html" class="nav-link">Dog Supplies</a></li>
                     <li>
                         <a href="#" class="nav-link" data-page="shop">Shop <i class="fas fa-chevron-down"></i></a>
                         <div class="dropdown">


### PR DESCRIPTION
## Summary
- update the main navigation links to use relative URLs so the dog supplies page works in subdirectory deployments
- adjust the breadcrumb home link to use a relative path for consistency

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_69023dd72b74832e8a15c7420fad1211