### PR TITLE
Fix navigation redirect for Home link on dog supplies page

### DIFF
--- a/dog-supplies.html
+++ b/dog-supplies.html
@@ -2384,7 +2384,7 @@
                         return;
                     }
                     event.preventDefault();
-                    window.location.href = `/index.html#${target}`;
+                    window.location.href = `index.html#${target}`;
                 });
             });
         });


### PR DESCRIPTION
## Summary
- update the nav routing helper in dog-supplies.html to use a relative index.html path so the Home navigation link works from the GitHub Pages deployment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6903b5343b4c832e8f4cd276d60289ad