### PR TITLE
Update dog supplies hero banner image

### DIFF
--- a/dog-supplies.html
+++ b/dog-supplies.html
@@ -370,7 +370,10 @@
         }
 
         .dog-hero {
-            background: linear-gradient(rgba(26, 26, 26, 0.45), rgba(26, 26, 26, 0.45)), url('images/dog-supplies/hero/dog-supplies-hero.svg') center/cover;
+            background: linear-gradient(rgba(26, 26, 26, 0.45), rgba(26, 26, 26, 0.45)), url('/images/banners/dogsuppliesbanner.png');
+            background-position: center;
+            background-size: cover;
+            background-repeat: no-repeat;
         }
 
         .cta-group {
@@ -917,6 +920,10 @@
 
             .hero h1 {
                 font-size: 2.3rem;
+            }
+
+            .dog-hero {
+                background-position: center top;
             }
 
             .promo-card img {


### PR DESCRIPTION
## Summary
- update the dog supplies hero banner to use the new /images/banners/dogsuppliesbanner.png artwork
- ensure the hero background covers the container without repeating and adjust mobile positioning for better focus

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_690679ae1e40832eadc056bf42c44b86