### PR TITLE
Revert hero banner update for dog supplies page

### DIFF
--- a/dog-supplies.html
+++ b/dog-supplies.html
@@ -370,10 +370,7 @@
         }
 
         .dog-hero {
-            background: linear-gradient(rgba(26, 26, 26, 0.45), rgba(26, 26, 26, 0.45)), url('/images/banners/dogsuppliesbanner.png');
-            background-position: center;
-            background-size: cover;
-            background-repeat: no-repeat;
+            background: linear-gradient(rgba(26, 26, 26, 0.45), rgba(26, 26, 26, 0.45)), url('images/dog-supplies/hero/dog-supplies-hero.svg') center/cover;
         }
 
         .cta-group {
@@ -920,10 +917,6 @@
 
             .hero h1 {
                 font-size: 2.3rem;
-            }
-
-            .dog-hero {
-                background-position: center top;
             }
 
             .promo-card img {


### PR DESCRIPTION
## Summary
- revert the merge of PR #29 so the dog supplies hero banner uses the original SVG asset and removes the associated responsive override

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69073d96b850832e9260be52882f9b90