### PR TITLE
Move Dog Supplies link under Shop menu

### DIFF
--- a/dog-supplies.html
+++ b/dog-supplies.html
@@ -993,11 +993,10 @@
             <div class="container-xl nav-inner">
                 <ul class="nav-links">
                     <li><a href="index.html" class="nav-link" data-page="home">Home</a></li>
-                    <li><a href="dog-supplies.html" class="nav-link active">Dog Supplies</a></li>
                     <li>
-                        <a href="#" class="nav-link" data-page="shop">Shop <i class="fas fa-chevron-down"></i></a>
+                        <a href="#" class="nav-link active" data-page="shop">Shop <i class="fas fa-chevron-down"></i></a>
                         <div class="dropdown">
-                            <a href="#" class="nav-link" data-page="dog-supplies">Dog Supplies</a>
+                            <a href="dog-supplies.html" class="nav-link">Dog Supplies</a>
                             <a href="#" class="nav-link" data-page="cat-supplies">Cat Supplies</a>
                             <a href="#" class="nav-link" data-page="small-pets">Small Pets</a>
                             <a href="#" class="nav-link" data-page="birds-reptiles">Birds &amp; Reptiles</a>

--- a/index.html
+++ b/index.html
@@ -1249,11 +1249,10 @@
             <div class="container-xl nav-inner">
                 <ul class="nav-links">
                     <li><a href="index.html" class="nav-link active" data-page="home">Home</a></li>
-                    <li><a href="dog-supplies.html" class="nav-link">Dog Supplies</a></li>
                     <li>
                         <a href="#" class="nav-link" data-page="shop">Shop <i class="fas fa-chevron-down"></i></a>
                         <div class="dropdown">
-                            <a href="#" class="nav-link" data-page="dog-supplies">Dog Supplies</a>
+                            <a href="dog-supplies.html" class="nav-link">Dog Supplies</a>
                             <a href="#" class="nav-link" data-page="cat-supplies">Cat Supplies</a>
                             <a href="#" class="nav-link" data-page="small-pets">Small Pets</a>
                             <a href="#" class="nav-link" data-page="birds-reptiles">Birds &amp; Reptiles</a>


### PR DESCRIPTION
## Summary
- remove the standalone Dog Supplies item from the main navigation bar
- link to the Dog Supplies page from the Shop dropdown as the first submenu entry
- keep the Shop item active on the Dog Supplies page so navigation context remains clear

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_6907ae4b900c832e9c765061e0d756fa